### PR TITLE
fix: adjust scrollbar on mobile

### DIFF
--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -79,8 +79,7 @@ const contentStyle = makeStyles({
         zIndex: 1
     },
     MenuButton: {
-        borderTopLeftRadius: cardCornerRadius,
-        borderBottomLeftRadius: cardCornerRadius,
+        borderRadius: `${cardCornerRadius}px 0 0 ${cardCornerRadius}px`,
         '&:hover': {
             background: KnowitColors.white
         },

--- a/src/components/NavBarMobile.tsx
+++ b/src/components/NavBarMobile.tsx
@@ -13,7 +13,6 @@ const drawerWidth = 240;
 
 const navbarStyles = makeStyles((theme) => ({
     toolbar: theme.mixins.toolbar,
-
     drawer: {
         // [theme.breakpoints.up('sm')]: {
         //   width: drawerWidth,
@@ -30,7 +29,7 @@ const navbarStyles = makeStyles((theme) => ({
         background: KnowitColors.greyGreen
     },
     menuButton: {
-        marginRight: theme.spacing(2),
+        marginRight: theme.spacing(1),
     },
     root: {
         flexGrow: 1,
@@ -147,7 +146,7 @@ const NavBarMobile = ({...props}: NavBarPropsMobile) => {
                         aria-label="menu" 
                         onClick={toggleDrawer(true)}
                     >
-                    <MenuIcon />
+                        <MenuIcon fontSize="large" />
                     </IconButton>
                     <Typography variant="h6" noWrap className={style.headerText}>
                         {navbarHeader()}

--- a/src/components/YourAnswersMobile.tsx
+++ b/src/components/YourAnswersMobile.tsx
@@ -49,10 +49,10 @@ const yourAnswersStyleMobile = makeStyles({
     categoryList: {
         height: 'min-content',
         backgroundColor: KnowitColors.beige,
-        borderRadius: '0px 0px 35px 35px',
-        paddingBottom: '25px',
-        boxShadow: "0px 3px 0px grey",
-        marginBottom: "3px",
+        paddingBottom: '18px',
+        marginBottom: "4px",
+        boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.15)",
+        borderRadius: "0px 0px 50px 50px",
     },
     navigationContainer: {
         width: '100%',
@@ -61,6 +61,7 @@ const yourAnswersStyleMobile = makeStyles({
         // zIndex: 1
     },
     navigationContainerScrolled: {
+        backgroundColor: "white",
         width: '100%',
         position: 'fixed',
         top: 56,
@@ -123,7 +124,9 @@ const yourAnswersStyleMobile = makeStyles({
     buttonText: {
         textTransform: 'none',
         textAlign: 'left',
-        justifyContent: 'left'
+        justifyContent: 'left',
+        fontSize: "14px",
+        lineHeight: "16px"
     },
     yourAnswersMobileContainer: {
         height: '100%',
@@ -138,11 +141,12 @@ const yourAnswersStyleMobile = makeStyles({
         },
         overflow: 'wrap',
         fontSize: 13,
-        fontWeight: 'bolder',
+        fontWeight: 'bold',
         border: 'none',
         justifyContent: 'left',
         borderRadius: '0px 17px 17px 0px',
-        width: 'fit-content' // todo denne kan tilbakestilles?
+        width: 'fit-content', // todo denne kan tilbakestilles?
+        padding: "10px 30px",
     },
 });
 


### PR DESCRIPTION
Closes #242 

## Fixed
- Space under scrollbar on mobile made opaque
- Menu shadow made to resemble Figma design
- Top/bottom-right border radius on side-menu buttons on desktop deleted to match design

### Before mobile
<img src="https://user-images.githubusercontent.com/16868802/106884357-816cd480-66e1-11eb-86a5-c8d962c1e95e.png" width="400" />

### After mobile
<img src="https://user-images.githubusercontent.com/16868802/106884636-de688a80-66e1-11eb-8915-3e09d652a249.png" width="400" />
