### PR TITLE
Fix: Highlights and overview graph alignment

### DIFF
--- a/src/components/CombinedChart.tsx
+++ b/src/components/CombinedChart.tsx
@@ -73,8 +73,8 @@ export const CombinedChart = ( {...props}: CombinedChartProps ) => {
     let classes = useStyles();
 
     return (
-        <div className={classes.combinedChartContainer}>
-        <ResponsiveContainer width='100%' height={heightPerColumn * props.chartData.length + 90}>     
+        <div className={classes.combinedChartContainer} style={{height: heightPerColumn * props.chartData.length + 90}}>
+        <ResponsiveContainer width='100%' height='100%'>     
             <BarChart barGap={-15} barSize={15} maxBarSize={15} layout="vertical" data={props.chartData} margin={{top: 50, right: 50, bottom: 6, left: 50}}>
             <CartesianGrid horizontal={true} vertical={true} strokeDasharray="2 5"/>
                 <XAxis

--- a/src/components/Highlights.tsx
+++ b/src/components/Highlights.tsx
@@ -9,14 +9,11 @@ import clsx from 'clsx';
 const barIconSize = 24;
 const barIconSizeMobile = 20;
 
-const topicWrapScaler = Math.round(window.innerWidth / 25);
-const maxTopicStringLength = Math.max(15, topicWrapScaler);
-
 const highlightsStyle = makeStyles({
     root: {
         display: 'flex',
         height: '40%',
-        width: '80%',
+        width: '100%',
         flexDirection: 'column',
         alignItems: 'flex-start'
     },
@@ -181,6 +178,19 @@ export default function Highlights({...props }: HighlightsProps) {
     
     const shortlistCutoff: number = 2.0;
     const maxInList: number = 4;
+
+    const maxLengthByWidth = (minNumLetters: number) => {
+        const width = Math.max(document.documentElement.clientWidth || 0, window.innerWidth || 0);
+        let factor = 27; //Scaling factor
+        let desktopPanelWidth = 0;
+        if (!props.isMobile) {
+            factor = 60; //Scaling factor for desktop
+            desktopPanelWidth = 0.2 * width; //Menu panel is 20% of width (Content.tsx)
+        }
+        const topicWrapScaler = Math.round((width - desktopPanelWidth) / factor);
+        return Math.max(minNumLetters, topicWrapScaler);
+    }
+    const maxTopicStringLength = maxLengthByWidth(8);
 
     useEffect(() => {
         generateShortlist();

--- a/src/components/ResultDiagram.tsx
+++ b/src/components/ResultDiagram.tsx
@@ -8,8 +8,7 @@ import Highlights from './Highlights';
 
 const graphStyle = makeStyles({
     resultDiagramContainer: {
-        width: '90%',
-        height: '60%',
+        width: '100%',
         paddingTop: 30
     },
     resultDiagramContainerMobile: {

--- a/src/components/cards/Overview.tsx
+++ b/src/components/cards/Overview.tsx
@@ -15,21 +15,21 @@ const overviewStyle = makeStyles({
         width: "100%",
         backgroundColor: KnowitColors.white,
         display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center'
+        flexDirection: 'column'
     },
     radarPlot: {
         height: '100%',
         width: '100%',
+        maxWidth: 1200,
         display: 'flex',
         flexDirection: 'column',
     },
     highlightsContainer: {
-        width: '90%',
+        width: '100%',
         height: '60%',
         paddingTop: 30,
         paddingLeft: 50,
-        marginTop: 50
+        marginTop: 20
     },
     mobile: {
         height: '100%',


### PR DESCRIPTION
- Highlights and graph are noe better aligned.
- Removed fixed vertical fixed percentage allotment so highlights doesn't end up too far down on large screens

Now:
![image](https://user-images.githubusercontent.com/73111792/107336372-4f7cb900-6ab9-11eb-86c8-81c782aa90cb.png)

Before:
![image](https://user-images.githubusercontent.com/73111792/107336278-3247ea80-6ab9-11eb-85e6-a08a504e2483.png)
