### PR TITLE
Tweaked styling to fit elements more consistently

### DIFF
--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -19,11 +19,11 @@ const useStyles = makeStyles({
         fontFamily: 'Arial',
         fontSize: '12px',
         fontWeight: 'bold',
-        paddingRight: "10px",
-        width: '5%'
+        width: 'fit-content',
+        paddingRight: '1vw'
     },
     bar: {
-        width: '95%'
+        flexGrow: 100
     }
 });
 

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
         paddingRight: '1vw'
     },
     bar: {
-        flexGrow: 100
+        flexGrow: 1
     }
 });
 


### PR DESCRIPTION
Now:
![Screen Shot 2021-02-11 at 15 34 56](https://user-images.githubusercontent.com/73111792/107650382-b8f9f480-6c7e-11eb-8346-a6dde56df2d2.png)

Before:
![Screen Shot 2021-02-11 at 15 34 53](https://user-images.githubusercontent.com/73111792/107650400-bd261200-6c7e-11eb-85b1-306c0bb7a044.png)
