### PR TITLE
feat: enabled tooltip on scale description fab on first time login on…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,7 @@ const App = () => {
         width: window.innerWidth,
     });
     const [scaleDescOpen, setScaleDescOpen] = useState(false);
+    const [firstTimeLogin, setFirstTimeLogin] = useState(false);
 
     useEffect(() => {
         const handleResize = debounce(() => {
@@ -288,10 +289,12 @@ const App = () => {
                         scrollToTop={scrollToTopMobile}
                         setCollapseMobileCategories={setCollapseMobileCategories}
                         setScaleDescOpen={setScaleDescOpen}
+                        setFirstTimeLogin={setFirstTimeLogin}
                     />
                     <FloatingScaleDescButton
                         scaleDescOpen={scaleDescOpen}
                         setScaleDescOpen={setScaleDescOpen}
+                        firstTimeLogin={firstTimeLogin}
                         isMobile={isMobile}
                     />
                 </Fragment>

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -191,7 +191,10 @@ const Content = ({...props}: ContentProps) => {
             setActivePanel(Panel.MyAnswers);
             setAnswerEditMode(true);
             setUserAnswersLoaded(true);
-            props.setScaleDescOpen(true);
+            props.setFirstTimeLogin(true);
+            if (!props.isMobile) {
+                props.setScaleDescOpen(true);
+            }
         }
         
         console.log("Last userform: ", lastUserForm);

--- a/src/components/FloatingScaleDescButton.tsx
+++ b/src/components/FloatingScaleDescButton.tsx
@@ -1,5 +1,5 @@
-import React, { Dispatch, SetStateAction, useState } from "react";
-import { Fab, makeStyles } from "@material-ui/core";
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Fab, Tooltip, makeStyles } from "@material-ui/core";
 import { KnowitColors } from "../styles";
 import DescriptionTable from "./DescriptionTable";
 
@@ -94,16 +94,38 @@ type FloatingScaleDescButtonProps = {
     isMobile: boolean;
     scaleDescOpen: boolean,
     setScaleDescOpen: Dispatch<SetStateAction<boolean>>,
+    firstTimeLogin: boolean,
 };
+
+type ConditionalWrapProps = {
+    condition: boolean,
+    wrap: (children: JSX.Element) => JSX.Element,
+    children: JSX.Element,
+}
+
+const ConditionalWrap = ({condition, wrap, children} : ConditionalWrapProps) => condition ? wrap(children) : children;
 
 const FloatingScaleDescButton = ({
     isMobile,
     scaleDescOpen,
     setScaleDescOpen,
+    firstTimeLogin,
 }: FloatingScaleDescButtonProps) => {
     const style = isMobile
         ? floatingScaleDescButtonStyleMobile()
         : floatingScaleDescButtonStyleDesktop();
+
+    const [showTooltip, setShowTooltip] = useState(firstTimeLogin)
+    useEffect(() => {
+        if (firstTimeLogin) {
+            setTimeout(() => setShowTooltip(false), 5000);
+        }
+    }, [firstTimeLogin])
+
+    const handleMobileFabClick = () => {
+        setShowTooltip(false);
+        setScaleDescOpen((scaleDescOpen) => !scaleDescOpen);
+    }
 
     return (
         <>
@@ -116,16 +138,24 @@ const FloatingScaleDescButton = ({
                 </div>
             )}
             {isMobile ?
-                <Fab
-                    size="small"
-                    variant="round"
-                    className={style.fab}
-                    onClick={() =>
-                        setScaleDescOpen((scaleDescOpen) => !scaleDescOpen)
-                    }
-                >
-                    ?
-                </Fab>
+             <ConditionalWrap condition={firstTimeLogin} wrap={children =>
+                 <Tooltip
+                     title="Trykk her for å se hva ikonene betyr!"
+                     open={showTooltip}
+                     arrow
+                 >
+                     {children}
+                 </Tooltip>
+             }>
+                 <Fab
+                     size="small"
+                     variant="round"
+                     className={style.fab}
+                     onClick={handleMobileFabClick}
+                 >
+                     ?
+                 </Fab>
+             </ConditionalWrap>
             :
                 <Fab
                     variant="extended"

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -413,6 +413,7 @@ export type ContentProps = {
     mobileNavRef:  React.MutableRefObject<HTMLInputElement | null>,
     setCollapseMobileCategories: (collapseMobileCategories: boolean) => void,
     setScaleDescOpen: Dispatch<SetStateAction<boolean>>,
+    setFirstTimeLogin: Dispatch<SetStateAction<boolean>>,
 };
 
 export type ChartData = {


### PR DESCRIPTION
… mobile

Scale description pane on mobile takes the entire screen which we
felt was too invasive without the user explicitly clicking the fab. There
is now a tooltip above the fab that automatically closes in 5 seconds.

### Preview
![image](https://user-images.githubusercontent.com/16868802/108065673-a7d62c80-705e-11eb-84eb-da7a7de6ae47.png)
