### PR TITLE
Scale description design tweaks

### DIFF
--- a/src/components/DescriptionTable.tsx
+++ b/src/components/DescriptionTable.tsx
@@ -21,13 +21,15 @@ const DescTableStyle = makeStyles({
         width: "100%",
         maxWidth: "100%",
         height: "100%",
-        maxHeight: "100%",
+        maxHeight: "inherit",
+        borderRadius: "inherit",
         display: "flex",
         flexDirection: "column",
         color: KnowitColors.darkBrown,
     },
     overflowContainer: {
         overflow: "auto",
+        borderRadius: "inherit",
     },
     scaleRow: {
         margin: "15px 20px",
@@ -211,7 +213,7 @@ export const DescriptionTable = ({
                 </div>
             )}
 
-            <div className={clsx({[style.overflowContainer]: isMobile})}>
+            <div className={style.overflowContainer}>
                 <div className={style.scaleRow}>
                     <header className={style.header}>
                         <h2 className={style.scaleTitle}>Kompetanseskala</h2>

--- a/src/components/FloatingScaleDescButton.tsx
+++ b/src/components/FloatingScaleDescButton.tsx
@@ -9,7 +9,7 @@ const floatingScaleDescButtonStyleDesktop = makeStyles({
         width: "fit-content",
         marginRight: "20px",
         marginBottom: "20px",
-        backgroundColor: KnowitColors.beige,
+        backgroundColor: KnowitColors.lightGreen,
         color: KnowitColors.darkBrown,
         position: "fixed",
         bottom: "0px",
@@ -24,16 +24,15 @@ const floatingScaleDescButtonStyleDesktop = makeStyles({
     fabMenu: {
         position: "absolute",
         alignSelf: "flex-end",
-        marginRight: "60px",
+        marginRight: "20px",
         marginBottom: "10px",
         bottom: "55px",
         right: "0px",
-        borderRadius: "50px 50px 50px 50px",
-        backgroundColor: KnowitColors.beige,
+        borderRadius: "50px 50px 0px 50px",
+        backgroundColor: KnowitColors.lightGreen,
         width: "400px",
         // viewport height - headerbar height - bottom margin height - other spacing
 	maxHeight: "calc(100vh - 66px - 55px - 20px)",
-        overflow: "auto",
         boxShadow:
             "0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)",
     },
@@ -48,14 +47,35 @@ const floatingScaleDescButtonStyleDesktop = makeStyles({
         right: "0px",
         top: "0px",
     },
+    arrow: {
+        width: "25px",
+        height: "12.5px",
+        position: "absolute",
+        top: "100%",
+        right: "5%",
+        transform: "translateX(-50%)",
+        overflow: "hidden",
+        "&:after": {
+            content: '""',
+            position: "absolute",
+            width: "10px",
+            height: "10px",
+            background: KnowitColors.lightGreen,
+            transform: "translateX(-50%) translateY(-50%) rotate(45deg)",
+            top: "0",
+            left: "50%",
+            boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.50)",
+        },
+    }
 });
 
 const floatingScaleDescButtonStyleMobile = makeStyles({
+    arrow: {},
     fab: {
         alignSelf: "flex-end",
         marginRight: "10px",
         marginBottom: "10px",
-        backgroundColor: KnowitColors.beige,
+        backgroundColor: KnowitColors.lightGreen,
         position: "fixed",
         bottom: "0px",
         right: "0px",
@@ -72,7 +92,7 @@ const floatingScaleDescButtonStyleMobile = makeStyles({
         width: "100%",
         height: "100%",
         zIndex: 101,
-        backgroundColor: KnowitColors.beige,
+        backgroundColor: KnowitColors.lightGreen,
         color: KnowitColors.darkBrown,
         boxShadow: "0px -4px 4px rgba(0, 0, 0, 0.15)",
         borderRadius: "50px 50px 0px 0px",
@@ -131,10 +151,11 @@ const FloatingScaleDescButton = ({
         <>
             {scaleDescOpen && (
                 <div className={style.fabMenu}>
-                    <DescriptionTable
-                        onClose={() => setScaleDescOpen(false)}
-                        isMobile={isMobile}
-                    />
+                        <DescriptionTable
+                            onClose={() => setScaleDescOpen(false)}
+                            isMobile={isMobile}
+                        />
+                    <div className={style.arrow}></div>
                 </div>
             )}
             {isMobile ?

--- a/src/components/FloatingScaleDescButton.tsx
+++ b/src/components/FloatingScaleDescButton.tsx
@@ -82,8 +82,8 @@ const floatingScaleDescButtonStyleMobile = makeStyles({
         fontFamily: "Arial",
         fontStyle: "normal",
         fontWeight: "bold",
-        fontSize: "15px",
-        lineHeight: "13px",
+        fontSize: "18px",
+        lineHeight: "16px",
     },
     fabMenu: {
         position: "fixed",
@@ -169,7 +169,7 @@ const FloatingScaleDescButton = ({
                  </Tooltip>
              }>
                  <Fab
-                     size="small"
+                     size="medium"
                      variant="round"
                      className={style.fab}
                      onClick={handleMobileFabClick}

--- a/src/components/FloatingScaleDescButton.tsx
+++ b/src/components/FloatingScaleDescButton.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { Fab, Tooltip, makeStyles } from "@material-ui/core";
+import { Fab, Tooltip, Modal, makeStyles } from "@material-ui/core";
 import { KnowitColors } from "../styles";
 import DescriptionTable from "./DescriptionTable";
 
@@ -20,6 +20,7 @@ const floatingScaleDescButtonStyleDesktop = makeStyles({
         fontSize: "11px",
         lineHeight: "13px",
         height: "35px",
+        zIndex: 1301, // modal backdrop z-index + 1
     },
     fabMenu: {
         position: "absolute",
@@ -32,9 +33,12 @@ const floatingScaleDescButtonStyleDesktop = makeStyles({
         backgroundColor: KnowitColors.lightGreen,
         width: "400px",
         // viewport height - headerbar height - bottom margin height - other spacing
-	maxHeight: "calc(100vh - 66px - 55px - 20px)",
+        maxHeight: "calc(100vh - 66px - 55px - 20px)",
         boxShadow:
             "0px 3px 5px -1px rgba(0,0,0,0.2), 0px 6px 10px 0px rgba(0,0,0,0.14), 0px 1px 18px 0px rgba(0,0,0,0.12)",
+        "&:focus": {
+            outline: "none",
+        },
     },
     closeButton: {
         marginTop: "15px",
@@ -66,7 +70,7 @@ const floatingScaleDescButtonStyleDesktop = makeStyles({
             left: "50%",
             boxShadow: "0px 0px 5px 0px rgba(0, 0, 0, 0.50)",
         },
-    }
+    },
 });
 
 const floatingScaleDescButtonStyleMobile = makeStyles({
@@ -112,18 +116,19 @@ const floatingScaleDescButtonStyleMobile = makeStyles({
 
 type FloatingScaleDescButtonProps = {
     isMobile: boolean;
-    scaleDescOpen: boolean,
-    setScaleDescOpen: Dispatch<SetStateAction<boolean>>,
-    firstTimeLogin: boolean,
+    scaleDescOpen: boolean;
+    setScaleDescOpen: Dispatch<SetStateAction<boolean>>;
+    firstTimeLogin: boolean;
 };
 
 type ConditionalWrapProps = {
-    condition: boolean,
-    wrap: (children: JSX.Element) => JSX.Element,
-    children: JSX.Element,
-}
+    condition: boolean;
+    wrap: (children: JSX.Element) => JSX.Element;
+    children: JSX.Element;
+};
 
-const ConditionalWrap = ({condition, wrap, children} : ConditionalWrapProps) => condition ? wrap(children) : children;
+const ConditionalWrap = ({ condition, wrap, children }: ConditionalWrapProps) =>
+    condition ? wrap(children) : children;
 
 const FloatingScaleDescButton = ({
     isMobile,
@@ -135,49 +140,59 @@ const FloatingScaleDescButton = ({
         ? floatingScaleDescButtonStyleMobile()
         : floatingScaleDescButtonStyleDesktop();
 
-    const [showTooltip, setShowTooltip] = useState(firstTimeLogin)
+    const [showTooltip, setShowTooltip] = useState(firstTimeLogin);
     useEffect(() => {
         if (firstTimeLogin) {
             setTimeout(() => setShowTooltip(false), 5000);
         }
-    }, [firstTimeLogin])
+    }, [firstTimeLogin]);
 
     const handleMobileFabClick = () => {
         setShowTooltip(false);
         setScaleDescOpen((scaleDescOpen) => !scaleDescOpen);
-    }
+    };
 
     return (
         <>
             {scaleDescOpen && (
-                <div className={style.fabMenu}>
+                <Modal
+                    open={scaleDescOpen}
+                    onClose={() =>
+                        setScaleDescOpen((scaleDescOpen) => !scaleDescOpen)
+                    }
+                >
+                    <div className={style.fabMenu}>
                         <DescriptionTable
                             onClose={() => setScaleDescOpen(false)}
                             isMobile={isMobile}
                         />
-                    <div className={style.arrow}></div>
-                </div>
+                        <div className={style.arrow}></div>
+                    </div>
+                </Modal>
             )}
-            {isMobile ?
-             <ConditionalWrap condition={firstTimeLogin} wrap={children =>
-                 <Tooltip
-                     title="Trykk her for å se hva ikonene betyr!"
-                     open={showTooltip}
-                     arrow
-                 >
-                     {children}
-                 </Tooltip>
-             }>
-                 <Fab
-                     size="medium"
-                     variant="round"
-                     className={style.fab}
-                     onClick={handleMobileFabClick}
-                 >
-                     ?
-                 </Fab>
-             </ConditionalWrap>
-            :
+            {isMobile ? (
+                <ConditionalWrap
+                    condition={firstTimeLogin}
+                    wrap={(children) => (
+                        <Tooltip
+                            title="Trykk her for å se hva ikonene betyr!"
+                            open={showTooltip}
+                            arrow
+                        >
+                            {children}
+                        </Tooltip>
+                    )}
+                >
+                    <Fab
+                        size="medium"
+                        variant="round"
+                        className={style.fab}
+                        onClick={handleMobileFabClick}
+                    >
+                        ?
+                    </Fab>
+                </ConditionalWrap>
+            ) : (
                 <Fab
                     variant="extended"
                     className={style.fab}
@@ -187,7 +202,7 @@ const FloatingScaleDescButton = ({
                 >
                     SKALABESKRIVELSE
                 </Fab>
-            }
+            )}
         </>
     );
 };


### PR DESCRIPTION
- Adds backdrop to scale description pane [desktop]
- Makes scale description FAB and panes green [desktop/mobile]
- Makes Scale description FAB larger (from `small` to `medium`) [mobile]
- Aligns FAB and pane along the right edge [desktop]
- Adds arrow to scale description pane towards FAB [desktop]

### Preview
#### Green FAB [mobile]
![image](https://user-images.githubusercontent.com/16868802/108215099-387d3d00-7131-11eb-90bf-7affef69ad23.png)

#### Green pane [mobile]
![image](https://user-images.githubusercontent.com/16868802/108215178-52b71b00-7131-11eb-9c0d-178161efa8ac.png)

#### Pane and FAB with backdrop [desktop]
![image](https://user-images.githubusercontent.com/16868802/108215273-6f535300-7131-11eb-8fee-3c493647e3ca.png)
