### PR TITLE
added scripts for removing items from dynamodb and adding categories,…

### DIFF
--- a/scripts/import_minimal_prod.py
+++ b/scripts/import_minimal_prod.py
@@ -1,0 +1,47 @@
+# Script for importing categories, question and formdefinition from the production environment of kompetansekartlegging
+
+import boto3
+import json
+
+
+with open('parameters.json') as parameters_file:
+    parameters = json.load(parameters_file)
+
+parameter_keys = ['source_iam_user', 'destination_iam_user', 'destination_graphql_api_id', 'destination_env']
+
+if not all(key in parameters for key in parameter_keys):
+    print(f"parameters.json must contain the following keys: f{parameter_keys}")
+    exit()
+
+source_graphql_api_id = 'uzksv2pimzhptdrxsv2igytjvi'
+source_env = 'prod'
+source_iam_user = parameters['source_iam_user']
+
+destination_iam_user = parameters['destination_iam_user']
+destination_graphql_api_id = parameters['destination_graphql_api_id']
+destination_env = parameters['destination_env']
+
+tablenames = ["Category", "Question", "FormDefinition"]
+
+source_client_session = boto3.Session(profile_name=source_iam_user)
+destination_client_session = boto3.Session(profile_name=destination_iam_user)
+
+source_dynamo_client = source_client_session.client('dynamodb')
+destination_dynamo_client = destination_client_session.client('dynamodb')
+
+for tablename in tablenames:
+    dynamopaginator = source_dynamo_client.get_paginator('scan')
+    source_tabname = tablename + '-' + source_graphql_api_id + '-' + source_env
+    destination_tabname = tablename + '-' + destination_graphql_api_id + '-' + destination_env
+    dynamoresponse = dynamopaginator.paginate(
+        TableName = source_tabname,
+        Select = 'ALL_ATTRIBUTES',
+        ReturnConsumedCapacity = 'NONE',
+        ConsistentRead = True
+    )
+    for page in dynamoresponse:
+        for item in page['Items']:
+            destination_dynamo_client.put_item(
+                TableName = destination_tabname,
+                Item = item
+            ) 

--- a/scripts/remove_items.py
+++ b/scripts/remove_items.py
@@ -1,0 +1,52 @@
+# Script for removing all the items from dynamodb in the production environment
+
+import boto3
+import json
+
+
+with open('parameters.json') as parameters_file:
+    parameters = json.load(parameters_file)
+
+
+parameter_keys = ['destination_iam_user', 'destination_graphql_api_id', 'destination_env']
+
+destination_iam_user = parameters['destination_iam_user']
+destination_graphql_api_id = parameters['destination_graphql_api_id']
+destination_env = parameters['destination_env']
+
+tablenames = ["User", "UserForm", "Category", "FormDefinition", "Group", "Question", "QuestionAnswer"]
+
+destination_client_session = boto3.Session(profile_name=destination_iam_user)
+
+destination_dynamo_client = destination_client_session.resource('dynamodb')
+
+def truncateTable(tableName):
+    table = destination_dynamo_client.Table(tableName)
+
+    #get the table keys
+    tableKeyNames = [key.get("AttributeName") for key in table.key_schema]
+
+    #Only retrieve the keys for each item in the table (minimize data transfer)
+    projectionExpression = ", ".join('#' + key for key in tableKeyNames)
+    expressionAttrNames = {'#'+key: key for key in tableKeyNames}
+
+    counter = 0
+    page = table.scan(ProjectionExpression=projectionExpression, ExpressionAttributeNames=expressionAttrNames)
+    with table.batch_writer() as batch:
+        while page["Count"] > 0:
+            counter += page["Count"]
+            # Delete items in batches
+            for itemKeys in page["Items"]:
+                batch.delete_item(Key=itemKeys)
+            # Fetch the next page
+            if 'LastEvaluatedKey' in page:
+                page = table.scan(
+                    ProjectionExpression=projectionExpression, ExpressionAttributeNames=expressionAttrNames,
+                    ExclusiveStartKey=page['LastEvaluatedKey'])
+            else:
+                break
+
+for tablename in tablenames:
+
+    full_table_name = tablename + '-' + destination_graphql_api_id + '-' + destination_env
+    truncateTable(full_table_name)


### PR DESCRIPTION
… questions and formdefinition from production environment

I have added two python scripts. 

1. "remove_items.py": A script for removing all items in the sandbox dynamodb.
2. "import_minimal_prod.py": A script for fetching categories, questions and formdefinition from the production environment of kompetansekartlegging.

The reason why the second script is added, is because import.py fetches a lot of data which clogs up the database and makes
it harder to see what is going on, such as questionanswers and users. The reason why the production environment is used, 
is because the development environment have many garbage items which have been added for testing purposes. 

The 3 scripts, import.py, import_minimal_prod.py and remove_items.py have a lot of common code, and should probably be refractored into a single script that is run using command-line arguments to select functionality. 